### PR TITLE
replace next/image with plain img tags to fix sharp/IPX errors

### DIFF
--- a/src/components/about/About.tsx
+++ b/src/components/about/About.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import styles from "./About.module.scss"
 
 export default function About() {
@@ -18,7 +17,8 @@ export default function About() {
                 <div className={styles.services}>
                     <div className={`${styles.service} reveal`} data-delay="1">
                         <div className={styles.service_icon}>
-                            <Image src="/images/software-development.svg" alt="frontend development" width={48} height={48} />
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img src="/images/software-development.svg" alt="frontend development" width={48} height={48} />
                         </div>
                         <div className={styles.service_content}>
                             <h3>Frontend Development</h3>
@@ -27,7 +27,8 @@ export default function About() {
                     </div>
                     <div className={`${styles.service} reveal`} data-delay="2">
                         <div className={styles.service_icon}>
-                            <Image src="/images/latest-tech.svg" alt="latest technologies" width={48} height={48} />
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img src="/images/latest-tech.svg" alt="latest technologies" width={48} height={48} />
                         </div>
                         <div className={styles.service_content}>
                             <h3>Latest Technology</h3>
@@ -36,7 +37,8 @@ export default function About() {
                     </div>
                     <div className={`${styles.service} reveal`} data-delay="3">
                         <div className={styles.service_icon}>
-                            <Image src="/images/result.svg" alt="100% end result" width={48} height={48} />
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img src="/images/result.svg" alt="100% end result" width={48} height={48} />
                         </div>
                         <div className={styles.service_content}>
                             <h3>100% End Result</h3>

--- a/src/components/banner/Banner.tsx
+++ b/src/components/banner/Banner.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import styles from "./Banner.module.scss"
 
 export default function Banner() {
@@ -35,29 +34,32 @@ export default function Banner() {
             </div>
 
             <div className={styles.image_side}>
-                <Image
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
                     src="/images/nitesh-image.png"
                     alt="Nitesh Raut — Senior Frontend Developer"
-                    fill
                     style={{ objectFit: 'cover', objectPosition: 'top center' }}
-                    priority
                 />
 
                 <div className={styles.tech_float}>
                     <div className={styles.tech_chip}>
-                        <Image src="/images/react.png" alt="React" width={20} height={20} />
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src="/images/react.png" alt="React" width={20} height={20} />
                         <span>React.js</span>
                     </div>
                     <div className={styles.tech_chip}>
-                        <Image src="/images/next.png" alt="Next.js" width={20} height={20} />
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src="/images/next.png" alt="Next.js" width={20} height={20} />
                         <span>Next.js</span>
                     </div>
                     <div className={styles.tech_chip}>
-                        <Image src="/images/typescript.png" alt="TypeScript" width={20} height={20} />
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src="/images/typescript.png" alt="TypeScript" width={20} height={20} />
                         <span>TypeScript</span>
                     </div>
                     <div className={styles.tech_chip}>
-                        <Image src="/images/redux.png" alt="Redux" width={20} height={20} />
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src="/images/redux.png" alt="Redux" width={20} height={20} />
                         <span>Redux</span>
                     </div>
                 </div>

--- a/src/components/latest-works/LatestWorks.tsx
+++ b/src/components/latest-works/LatestWorks.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import styles from "./LatestWorks.module.scss"
 
 const works: { title: string; href: string; image: string; tag: string }[] = [
@@ -31,7 +30,8 @@ export default function LatestWorks() {
                             data-delay={String((i % 3) + 1)}
                         >
                             <div className={styles.work_image}>
-                                <Image src={work.image} alt={work.title} fill style={{ objectFit: 'cover' }} />
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img src={work.image} alt={work.title} style={{ objectFit: 'cover' }} />
                                 <div className={styles.overlay}>
                                     <span className={styles.visit_label}>Visit Site →</span>
                                 </div>


### PR DESCRIPTION
next/image routes through the image optimization pipeline which requires sharp. Plain img tags serve images directly from public/images/ with no server-side processing needed.